### PR TITLE
Improve error msg

### DIFF
--- a/cmd/vimlparser/main.go
+++ b/cmd/vimlparser/main.go
@@ -35,6 +35,7 @@ func main() {
 				flag.Usage()
 			}
 			exitCode = 1
+			continue
 		}
 		if err := parseFile(f.Name(), f, os.Stdout, opt); err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/cmd/vimlparser/main.go
+++ b/cmd/vimlparser/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/haya14busa/go-vimlparser"
@@ -14,26 +15,46 @@ var neovim = flag.Bool("neovim", false, "use neovim parser")
 func main() {
 	flag.Parse()
 
-	r := os.Stdin
+	opt := &vimlparser.ParseOption{Neovim: *neovim}
 
-	if p := flag.Arg(0); p != "" {
-		f, err := os.Open(p)
-		if err != nil {
+	if len(flag.Args()) == 0 {
+		if err := parseFile("", os.Stdin, os.Stdout, opt); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			flag.Usage()
 			os.Exit(1)
 		}
-		r = f
+		os.Exit(0)
 	}
 
-	node, err := vimlparser.ParseFile(r, &vimlparser.ParseOption{Neovim: *neovim})
+	exitCode := 0
+
+	for i, file := range flag.Args() {
+		f, err := os.Open(file)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			if i == 0 {
+				flag.Usage()
+			}
+			exitCode = 1
+		}
+		if err := parseFile(f.Name(), f, os.Stdout, opt); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			exitCode = 1
+		}
+	}
+
+	os.Exit(exitCode)
+}
+
+// filename is empty string if r is os.Stdin
+func parseFile(filename string, r io.ReadCloser, w io.Writer, opt *vimlparser.ParseOption) error {
+	defer r.Close()
+	node, err := vimlparser.ParseFile(r, filename, opt)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
 	c := &compiler.Compiler{Config: compiler.Config{Indent: "  "}}
-	if err := c.Compile(os.Stdout, node); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+	if err := c.Compile(w, node); err != nil {
+		return err
 	}
+	return nil
 }

--- a/cmd/vimlparser/main.go
+++ b/cmd/vimlparser/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/haya14busa/go-vimlparser"
@@ -19,18 +19,21 @@ func main() {
 	if p := flag.Arg(0); p != "" {
 		f, err := os.Open(p)
 		if err != nil {
-			log.Fatal(err)
+			fmt.Fprintln(os.Stderr, err)
 			flag.Usage()
+			os.Exit(1)
 		}
 		r = f
 	}
 
 	node, err := vimlparser.ParseFile(r, &vimlparser.ParseOption{Neovim: *neovim})
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 	c := &compiler.Compiler{Config: compiler.Config{Indent: "  "}}
 	if err := c.Compile(os.Stdout, node); err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -35,7 +35,7 @@ func TestCompiler_Compile(t *testing.T) {
 	}
 }
 
-const okErrPrefix = "go-vimlparser:Parse: vimlparser: "
+const okErrPrefix = "vimlparser: "
 
 func testFile(t *testing.T, file, okfile string) {
 	opt := &vimlparser.ParseOption{Neovim: strings.Contains(file, "test_neo")}
@@ -44,7 +44,7 @@ func testFile(t *testing.T, file, okfile string) {
 		t.Fatal(err)
 	}
 	defer in.Close()
-	node, err := vimlparser.ParseFile(in, opt)
+	node, err := vimlparser.ParseFile(in, "", opt)
 	if err != nil {
 		if !strings.HasPrefix(err.Error(), okErrPrefix) {
 			t.Error(err)
@@ -81,7 +81,7 @@ func BenchmarkCompiler_Compile(b *testing.B) {
 		b.Fatal(err)
 	}
 	defer in.Close()
-	node, err := vimlparser.ParseFile(in, opt)
+	node, err := vimlparser.ParseFile(in, "", opt)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/go/_test/special.vim
+++ b/go/_test/special.vim
@@ -69,6 +69,10 @@ function! s:ExArg()
   " skip ExArg definition
 endfunction
 
+function! s:Err()
+  " skip Err
+endfunction
+
 let self.hoge = 1
 let self.ea.range = 1
 let xxx.x = 1

--- a/go/_test/typedefs.go
+++ b/go/_test/typedefs.go
@@ -1,9 +1,6 @@
 func isalpha(c string) bool {
 }
 
-func Err(msg string, pos *pos) string {
-}
-
 func (self *VimLParser) find_context(type_ int) int {
 }
 

--- a/go/_test/typedefs.vim
+++ b/go/_test/typedefs.vim
@@ -1,9 +1,6 @@
 function! s:isalpha(c)
 endfunction
 
-function! s:Err(msg, pos)
-endfunction
-
 function! s:VimLParser.find_context(type_)
 endfunction
 

--- a/go/gocompiler.vim
+++ b/go/gocompiler.vim
@@ -341,7 +341,7 @@ function s:GoCompiler.compile_function(node)
       let out .= ' '
     endif
   endif
-  if left =~ '^\(ExArg\|Node\)$'
+  if left =~ '^\(ExArg\|Node\|Err\)$'
     return
   elseif left =~ '^\(VimLParser\|ExprTokenizer\|ExprParser\|LvalueParser\|StringReader\|Compiler\|RegexpParser\)\.'
     let [_0, struct, name; _] = matchlist(left, '^\(.*\)\.\(.*\)$')

--- a/go/type.go
+++ b/go/type.go
@@ -1,6 +1,9 @@
 package vimlparser
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type ExArg struct {
 	forceit      bool
@@ -296,10 +299,24 @@ func (self *Compiler) compile_dict(n *VimNode) string {
 		kv := nn.([]interface{})
 		value = append(value, "("+self.compile(kv[0].(*VimNode)).(string)+" "+self.compile(kv[1].(*VimNode)).(string)+")")
 	}
-	// var value = viml_map(VimNode.value, "\"(\" . self.compile(v:val[0]) . \" \" . self.compile(v:val[1]) . \")\"")
 	if viml_empty(value) {
 		return "(dict)"
 	} else {
 		return viml_printf("(dict %s)", strings.Join(value, " "))
 	}
+}
+
+type ParseError struct {
+	Offset int
+	Line   int
+	Column int
+	Msg    string
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("vimlparser: %s: line %d col %d", e.Msg, e.Line, e.Column)
+}
+
+func Err(msg string, pos *pos) *ParseError {
+	return &ParseError{Offset: pos.i, Line: pos.lnum, Column: pos.col, Msg: msg}
 }

--- a/go/typedefs.vim
+++ b/go/typedefs.vim
@@ -2,10 +2,6 @@
 
 let s:typedefs = {
 \   'func': {
-\     'Err': {
-\       'in': ['string', '*pos'],
-\       'out': ['string'],
-\     },
 \   },
 \ }
 

--- a/go/vimlparser.go
+++ b/go/vimlparser.go
@@ -328,10 +328,6 @@ func islower(c string) bool {
 // CURLYNAMEPART .value
 // CURLYNAMEEXPR .value
 // LAMBDA .rlist .left
-func Err(msg string, pos *pos) string {
-	return viml_printf("vimlparser: %s: line %d col %d", msg, pos.lnum, pos.col)
-}
-
 func (self *VimLParser) find_context(type_ int) int {
 	var i = 0
 	for _, node := range self.context {

--- a/vimlparser.go
+++ b/vimlparser.go
@@ -20,7 +20,7 @@ func ParseFile(r io.Reader, opt *ParseOption) (node *ast.File, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			node = nil
-			err = fmt.Errorf("go-vimlparser:Parse: %v", r)
+			err = fmt.Errorf("%v", r)
 			// log.Printf("%s", debug.Stack())
 		}
 	}()
@@ -39,7 +39,7 @@ func ParseExpr(r io.Reader) (node ast.Expr, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			node = nil
-			err = fmt.Errorf("go-vimlparser:Parse: %v", r)
+			err = fmt.Errorf("%v", r)
 			// log.Printf("%s", debug.Stack())
 		}
 	}()

--- a/vimlparser.go
+++ b/vimlparser.go
@@ -16,7 +16,8 @@ type ParseOption struct {
 }
 
 // ParseFile parses Vim script.
-func ParseFile(r io.Reader, opt *ParseOption) (node *ast.File, err error) {
+// filename can be empty.
+func ParseFile(r io.Reader, filename string, opt *ParseOption) (node *ast.File, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			node = nil

--- a/vimlparser.go
+++ b/vimlparser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/haya14busa/go-vimlparser/internal/exporter"
 )
 
+// ErrVimlParser represents VimLParser error.
 type ErrVimlParser struct {
 	Filename string
 	Offset   int

--- a/vimlparser.go
+++ b/vimlparser.go
@@ -66,7 +66,16 @@ func ParseExpr(r io.Reader) (node ast.Expr, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			node = nil
-			err = fmt.Errorf("%v", r)
+			if e, ok := r.(*internal.ParseError); ok {
+				err = &ErrVimlParser{
+					Offset: e.Offset,
+					Line:   e.Line,
+					Column: e.Column,
+					Msg:    e.Msg,
+				}
+			} else {
+				err = fmt.Errorf("%v", r)
+			}
 			// log.Printf("%s", debug.Stack())
 		}
 	}()

--- a/vimlparser_test.go
+++ b/vimlparser_test.go
@@ -15,7 +15,7 @@ func TestParseFile_can_parse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	okErr := "go-vimlparser:Parse: vimlparser:"
+	okErr := "vimlparser:"
 	match = append(match, "autoload/vimlparser.vim")
 	match = append(match, "go/gocompiler.vim")
 	for _, filename := range match {
@@ -31,7 +31,7 @@ func checkParse(t testing.TB, filename string) error {
 		t.Error(err)
 	}
 	defer in.Close()
-	_, err = ParseFile(in, nil)
+	_, err = ParseFile(in, "", nil)
 	return err
 }
 
@@ -58,7 +58,7 @@ func TestParseExpr_Compile(t *testing.T) {
 }
 
 func TestParseExpr_Parser_err(t *testing.T) {
-	want := "go-vimlparser:Parse: vimlparser: unexpected token: /: line 1 col 4"
+	want := "vimlparser: unexpected token: /: line 1 col 4"
 	_, err := ParseExpr(strings.NewReader("1 // 2"))
 	if err != nil {
 		if got := err.Error(); want != got {

--- a/vimlparser_test.go
+++ b/vimlparser_test.go
@@ -42,6 +42,21 @@ func BenchmarkParseFile(b *testing.B) {
 	}
 }
 
+func TestParseFile_error(t *testing.T) {
+	want := "path/to/filename.go:1:1: vimlparser: E492: Not an editor command: hoge"
+	_, err := ParseFile(strings.NewReader("hoge"), "path/to/filename.go", nil)
+	if err != nil {
+
+		if er, ok := err.(*ErrVimlParser); !ok {
+			t.Errorf("Error type is %T, want %T", er, &ErrVimlParser{})
+		}
+
+		if got := err.Error(); want != got {
+			t.Errorf("ParseFile(\"hoge\") = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestParseExpr_Compile(t *testing.T) {
 	node, err := ParseExpr(strings.NewReader("x + 1"))
 	if err != nil {

--- a/vimlparser_test.go
+++ b/vimlparser_test.go
@@ -76,6 +76,11 @@ func TestParseExpr_Parser_err(t *testing.T) {
 	want := "vimlparser: unexpected token: /: line 1 col 4"
 	_, err := ParseExpr(strings.NewReader("1 // 2"))
 	if err != nil {
+
+		if er, ok := err.(*ErrVimlParser); !ok {
+			t.Errorf("Error type is %T, want %T", er, &ErrVimlParser{})
+		}
+
 		if got := err.Error(); want != got {
 			t.Errorf("ParseExpr(\"1 // 2\") = %v, want %v", got, want)
 		}


### PR DESCRIPTION
```
$ vimlparser autoload/**/*.vim 2>&1 >/dev/null
autoload/go/coverage.vim:92:1: vimlparser: E171: Missing :endif:    ENDFUNCTION
autoload/go/fmt.vim:185:9: vimlparser: E492: Not an editor command: | " Couldn't detect gofmt error format, output errors
```

```
$ echo 'hoge' | vimlparser
vimlparser: E492: Not an editor command: hoge: line 1 col 1
```
