### PR TITLE
Fix walk processing when node type is if

### DIFF
--- a/ast/walk.go
+++ b/ast/walk.go
@@ -71,6 +71,7 @@ func Walk(v Visitor, node Node) {
 
 	case *If:
 		Walk(v, n.Condition)
+		walkStmtList(v, n.Body)
 		for _, elseif := range n.ElseIf {
 			Walk(v, elseif)
 		}


### PR DESCRIPTION
@haya14busa
When "Walk" while the type of node is "*If" does not "Walk" inside n.Body.
I fixed.