### PR TITLE
avoid using reflect and reduce allocs

### DIFF
--- a/go/vimlfunc.go
+++ b/go/vimlfunc.go
@@ -147,6 +147,20 @@ func viml_string(obj interface{}) string {
 }
 
 func viml_has_key(obj interface{}, key interface{}) bool {
+	// Avoid using reflect as much as possible by listing type used as obj and
+	// use type switch.
+	switch o := obj.(type) {
+	case map[string]*Cmd:
+		_, ok := o[key.(string)]
+		return ok
+	case map[string]interface{}:
+		_, ok := o[key.(string)]
+		return ok
+	case map[int][]interface{}:
+		_, ok := o[key.(int)]
+		return ok
+	}
+	// fallback to reflect. Shoul be unreachable.
 	m := reflect.ValueOf(obj)
 	v := m.MapIndex(reflect.ValueOf(key))
 	return v.Kind() != reflect.Invalid


### PR DESCRIPTION
```
benchmark                old ns/op     new ns/op     delta
BenchmarkParseFile-4     217023226     199891609     -7.89%

benchmark                old allocs     new allocs     delta
BenchmarkParseFile-4     1179043        955346         -18.97%

benchmark                old bytes     new bytes     delta
BenchmarkParseFile-4     45851108      41793534      -8.85%
```
